### PR TITLE
Add ArgoCD application configuration for managing deployments

### DIFF
--- a/argocd-apps.yaml
+++ b/argocd-apps.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-apps
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/MCCE2024/INENPT-G1-Argo.git
+    targetRevision: main
+    path: applications
+    directory:
+      recurse: true
+      include: "*/argocd-application.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
- Introduced a new ArgoCD application configuration file (argocd-apps.yaml) to manage deployments from a specified Git repository.
- Configured automated sync policies with options for pruning and self-healing, and set the target namespace to 'argocd'.
- The configuration supports recursive directory inclusion for application manifests.