### PR TITLE
Refactor Helm templates and update ArgoCD configuration

### DIFF
--- a/applications/consumer/argocd-application.yaml
+++ b/applications/consumer/argocd-application.yaml
@@ -21,7 +21,7 @@ spec:
           secret: ""  # Will be set via secret
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    namespace: test-tenant
   syncPolicy:
     automated:
       prune: true

--- a/applications/consumer/helm/templates/_helpers.tpl
+++ b/applications/consumer/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "consumer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "consumer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "consumer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "consumer.labels" -}}
+helm.sh/chart: {{ include "consumer.chart" . }}
+{{ include "consumer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "consumer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "consumer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "consumer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "consumer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }} 

--- a/applications/consumer/helm/templates/deployment.yaml
+++ b/applications/consumer/helm/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "consumer.fullname" . }}
+  labels:
+    {{- include "consumer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "consumer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "consumer.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "consumer.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: CONSUMER_PORT
+              value: "3000"
+            - name: TENANT_NAME
+              value: {{ .Values.tenant.name | quote }}
+            - name: TENANT_PORT
+              value: {{ .Values.tenant.port | quote }}
+            - name: API_BASE_URL
+              value: {{ .Values.api.baseUrl | quote }}
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: consumer-oauth-secret
+                  key: github-client-id
+                  optional: true
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: consumer-oauth-secret
+                  key: github-client-secret
+                  optional: true
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: consumer-oauth-secret
+                  key: session-secret
+                  optional: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }} 

--- a/applications/consumer/helm/templates/service.yaml
+++ b/applications/consumer/helm/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "consumer.fullname" . }}
+  labels:
+    {{- include "consumer.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.tenant.port }}
+      nodePort: {{ .Values.tenant.port }}
+      {{- end }}
+  selector:
+    {{- include "consumer.selectorLabels" . | nindent 4 }} 

--- a/applications/consumer/helm/values.yaml
+++ b/applications/consumer/helm/values.yaml
@@ -38,7 +38,7 @@ github:
 
 # API configuration
 api:
-  baseUrl: "http://api-service:3000"
+  baseUrl: "http://api-service:80"
 
 # Session configuration
 session:


### PR DESCRIPTION
- Changed the target namespace in ArgoCD application configuration from 'default' to 'test-tenant' for better environment segregation.
- Updated API base URL in Helm values to use port 80 for improved accessibility.
- Added new Helm templates for deployment and service, including common helper functions for naming and labeling.
- Enhanced deployment configuration with environment variables and health check settings for better service management.