### PR TITLE
Update tenant name in ArgoCD application and Helm values configuration

### DIFF
--- a/applications/consumer/argocd-application.yaml
+++ b/applications/consumer/argocd-application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       values: |
         tenant:
-          name: "tenant-a"
+          name: "test-tenant"
           port: 30000
         github:
           clientId: ""  # Will be set via secret

--- a/applications/consumer/helm/values.yaml
+++ b/applications/consumer/helm/values.yaml
@@ -22,7 +22,7 @@ securityContext: {}
 
 # Tenant configuration
 tenant:
-  name: "tenant-a" # Will be overridden per deployment
+  name: "test-tenant" # Will be overridden per deployment
   port: 30000 # Will be overridden per deployment
 
 # Service configuration


### PR DESCRIPTION
- Changed tenant name from 'tenant-a' to 'test-tenant' in both argocd-application.yaml and values.yaml for consistency across configurations.